### PR TITLE
feat(ui.tsx): Add persist setting support

### DIFF
--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -60,6 +60,10 @@ const initialState = {
   progress: (null as number | null),
 };
 
+// Utilize the default state and then overwrite any values that were set and persisted previously
+const persistedPlanOptions = JSON.parse(window.localStorage.getItem("planOptions")) || {};
+initialState.planOptions = {...initialState.planOptions, ...persistedPlanOptions};
+
 type State = typeof initialState;
 
 const DispatchContext = React.createContext(null);
@@ -603,6 +607,20 @@ function PlotButtons(
   </div>;
 }
 
+function ResetToDefaultsButton() {
+  const dispatch = useContext(DispatchContext);
+  const onClick = () => {
+    // Utilize the default state to clear all user settings that have been saved
+    window.localStorage.removeItem("planOptions");
+    dispatch({type: "SET_PLAN_OPTION", value: {...defaultPlanOptions}});
+  };
+
+  return <div>
+    <button onClick={onClick}>reset all options</button>
+  </div>;
+
+}
+
 function PlanOptions({state}: {state: State}) {
   const dispatch = useContext(DispatchContext);
   return <div>
@@ -727,6 +745,9 @@ function Root({driver}: {driver: Driver}) {
   const [state, dispatch] = useReducer(reducer, initialState);
   const [isPlanning, plan, setPlan] = usePlan(state.paths, state.planOptions);
   useEffect(() => {
+    window.localStorage.setItem("planOptions", JSON.stringify(state.planOptions));
+  }, [state.planOptions]);
+  useEffect(() => {
     driver.onprogress = (motionIdx: number) => {
       dispatch({type: "SET_PROGRESS", motionIdx});
     };
@@ -794,6 +815,7 @@ function Root({driver}: {driver: Driver}) {
         <div className="section-body">
           <PenHeight state={state} driver={driver} />
           <MotorControl driver={driver} />
+          <ResetToDefaultsButton/>
         </div>
         <div className="section-header">paper</div>
         <div className="section-body">


### PR DESCRIPTION
Adds support for persisting planOption configurations by persisting to localStorage.

Also adds support for resetting planOptions to defaults defined by the application if the user has persisted changes.

## Overview

![saxi 2019-03-28 15-40-21](https://user-images.githubusercontent.com/2549228/55194621-e3686480-516f-11e9-807b-dc5d62ff1602.png)

## Thoughts

### Location of button

The location of the button is kind of dorky. I didn't have a good thought on where I should put that. I'm open to feedback.

### Test images

It would be good to have a set of test images embedded into the repo that you can use to click test the repo with.

Also, it would be good to have the same images in case you want to update the documentation in the readme. For example, I added a new button so that wouldn't be visible in the readme at this point.

### Similar refactor

Loved the defaultPlanOptions refactor you just did. I was actually doing the same thing in my fork as well but with the whole state object so that worked out nice. :)

### localStorage

For now localStorage will suffice, but I was thinking it would be interesting to move to kvstorage. You can read more about it here: https://developers.google.com/web/updates/2019/03/kv-storage. This is of course a shiny and nice to have, so not a huge deal.

### Reorg

I know it can be difficult to start making piles of files, but what's your take on starting to split ui.tsx out at some point?

fixes: #29 
