### PR TITLE
Interface Style Updates

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -229,8 +229,10 @@ select[multiple]:focus option:checked {
   color: white;
 }
 
-.flex button {
+.flex button,
+.flex label {
   width: calc(50% - 0.25rem);
+  align-self: flex-end;
 }
 
 /* PEN section */

--- a/src/style.css
+++ b/src/style.css
@@ -89,16 +89,12 @@ path {
 }
 
 .drag-target-message {
-  width: 50%;
-  height: 50%;
-  border: 8px dashed grey;
   display: flex;
   justify-content: center;
   align-items: center;
   color: whitesmoke;
-  background: rgba(255,255,255,0.25);
   font-weight: bold;
-  font-size: 60px;
+  font-size: 36px;
 }
 
 .control-panel {

--- a/src/style.css
+++ b/src/style.css
@@ -209,16 +209,17 @@ button, select {
 }
 
 button:not(:disabled):hover,
-select:not(:disabled):hover,
 button:not(:disabled):focus,
+select:not(:disabled):hover,
 select:focus,
 input[type=number]:hover,
-input[type=number]:focus {
-  box-shadow: 1px 1px 2px rgba(0, 0, 0, 0.25);
+input[type=number]:focus,
+input[type=checkbox]:focus {
+  box-shadow: 1px 2px 5px rgba(0, 0, 0, 0.25);
 }
 
 button:not(:disabled):active {
-  box-shadow: 0px 0px 1px rgba(0, 0, 0, 0.25), inset 1px 1px 1px rgba(0, 0, 0, 0.1);
+  box-shadow: 0px 0px 1px rgba(0, 0, 0, 0.25), inset 2px 2px 5px rgba(0, 0, 0, 0.2);
   background-color: #fafafa;
   color: var(--purple-dark);
 }
@@ -316,6 +317,10 @@ select[multiple]:focus option:checked {
 summary {
   outline: none;
   cursor: pointer;
+}
+
+summary:focus {
+  color: var(--purple-dark);
 }
 
 .horizontal-labels label {

--- a/src/style.css
+++ b/src/style.css
@@ -173,7 +173,7 @@ input[type=checkbox] {
   -webkit-appearance: none;
   width: 18px;
   height: 18px;
-  margin-right: 8px;
+  margin: 0 0.5rem 0 0;
   border: 1px solid var(--purple);
   background-color: white;
   box-shadow: 1px 1px 2px rgba(0, 0, 0, 0.1);
@@ -263,6 +263,8 @@ select[multiple]:focus option:checked {
 .flex-checkbox {
   display: flex;
   align-items: center;
+  justify-content: center;
+  margin-bottom: 0.5rem;
 }
 
 /* PEN section */

--- a/src/style.css
+++ b/src/style.css
@@ -167,6 +167,31 @@ input[type=number] {
   outline: none;
 }
 
+input[type=checkbox] {
+  position: relative;
+  appearance: none;
+  -webkit-appearance: none;
+  width: 18px;
+  height: 18px;
+  margin-right: 8px;
+  border: 1px solid var(--purple);
+  background-color: white;
+  box-shadow: 1px 1px 2px rgba(0, 0, 0, 0.1);
+  outline: none;
+  cursor: pointer;
+}
+
+input[type=checkbox]:checked:after {
+  display: block;
+  position: absolute;
+  top: 3px;
+  right: 3px;
+  bottom: 3px;
+  left: 3px;
+  content: '';
+  background-color: var(--purple);
+}
+
 button, select {
   width: 100%;
   margin-bottom: 0.5rem;
@@ -233,6 +258,11 @@ select[multiple]:focus option:checked {
 .flex label {
   width: calc(50% - 0.25rem);
   align-self: flex-end;
+}
+
+.flex-checkbox {
+  display: flex;
+  align-items: center;
 }
 
 /* PEN section */

--- a/src/style.css
+++ b/src/style.css
@@ -198,6 +198,26 @@ button:not(:disabled):active {
   color: var(--purple-dark);
 }
 
+/* button-link is a button element that looks like a link */
+button.button-link {
+  display: block;
+  padding: 0;
+  border: none;
+  font-size: 10px;
+  text-decoration: none;
+  background-color: transparent;
+  box-shadow: none;
+  font-weight: 400;
+}
+
+button.button-link:hover,
+button.button-link:active,
+button.button-link:focus {
+  box-shadow: none;
+  background-color: transparent;
+  text-decoration: underline;
+}
+
 select {
   height: 30px;
   appearance: none;

--- a/src/style.css
+++ b/src/style.css
@@ -317,14 +317,27 @@ summary {
 }
 
 .horizontal-labels label {
-  display: flex;
+  display: block;
+  position: relative;
 }
-.horizontal-labels label > :first-child {
-  width: 32px;
-  flex: 0;
+.horizontal-labels label::after {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 28px;
+  border-right: 1px solid var(--purple);
 }
-.horizontal-labels label > input {
-  flex: 1;
+
+.horizontal-labels img {
+  position: absolute;
+  padding: 4px;
+  width: 28px;
+  height: 28px;
+  border-right: 1px solid var(--purple);
+  /*opacity: 0.5;*/
+}
+.horizontal-labels input {
+  padding-left: 32px;
 }
 
 /* PLOT section */

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -625,7 +625,7 @@ function PlanOptions({state}: {state: State}) {
   return <div>
     <div className="horizontal-labels">
       <label title="point-joining radius (mm)" >
-        <img src={pointJoinRadiusIcon} style={{height: 28}} alt="point-joining radius (mm)"/>
+        <img src={pointJoinRadiusIcon} alt="point-joining radius (mm)"/>
         <input
           type="number"
           value={state.planOptions.pointJoinRadius}
@@ -635,7 +635,7 @@ function PlanOptions({state}: {state: State}) {
         />
       </label>
       <label title="path-joining radius (mm)">
-        <img src={pathJoinRadiusIcon} style={{height: 28}} alt="path-joining radius (mm)" />
+        <img src={pathJoinRadiusIcon} alt="path-joining radius (mm)" />
         <input
           type="number"
           value={state.planOptions.pathJoinRadius}

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -738,8 +738,8 @@ function PlanOptions({state}: {state: State}) {
             min="0"
             onChange={(e) => dispatch({type: "SET_PLAN_OPTION", value: {penDropDuration: Number(e.target.value)}})}
           />
-        </div>
-      </label>
+        </label>
+      </div>
     </div>
   </div>;
 }

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -666,26 +666,28 @@ function PlanOptions({state}: {state: State}) {
           onChange={(e) => dispatch({type: "SET_PLAN_OPTION", value: {minimumPathLength: Number(e.target.value)}})}
         />
       </label>
-      <label>
-        pen-down acceleration (mm/s<sup>2</sup>)
-        <input
-          type="number"
-          value={state.planOptions.penDownAcceleration}
-          step="0.1"
-          min="0"
-          onChange={(e) => dispatch({type: "SET_PLAN_OPTION", value: {penDownAcceleration: Number(e.target.value)}})}
-        />
-      </label>
-      <label>
-        pen-down max velocity (mm/s)
-        <input
-          type="number"
-          value={state.planOptions.penDownMaxVelocity}
-          step="0.1"
-          min="0"
-          onChange={(e) => dispatch({type: "SET_PLAN_OPTION", value: {penDownMaxVelocity: Number(e.target.value)}})}
-        />
-      </label>
+      <div className="flex">
+        <label title="Acceleration when the pen is down (in mm/s^2)">
+          down acc. (mm/s<sup>2</sup>)
+          <input
+            type="number"
+            value={state.planOptions.penDownAcceleration}
+            step="0.1"
+            min="0"
+            onChange={(e) => dispatch({type: "SET_PLAN_OPTION", value: {penDownAcceleration: Number(e.target.value)}})}
+          />
+        </label>
+        <label title="Maximum velocity when the pen is down (in mm/s)">
+          down max vel. (mm/s)
+          <input
+            type="number"
+            value={state.planOptions.penDownMaxVelocity}
+            step="0.1"
+            min="0"
+            onChange={(e) => dispatch({type: "SET_PLAN_OPTION", value: {penDownMaxVelocity: Number(e.target.value)}})}
+          />
+        </label>
+      </div>
       <label>
         cornering factor
         <input
@@ -696,45 +698,49 @@ function PlanOptions({state}: {state: State}) {
           onChange={(e) => dispatch({type: "SET_PLAN_OPTION", value: {penDownCorneringFactor: Number(e.target.value)}})}
         />
       </label>
-      <label>
-        pen-up acceleration (mm/s<sup>2</sup>)
-        <input
-          type="number"
-          value={state.planOptions.penUpAcceleration}
-          step="0.1"
-          min="0"
-          onChange={(e) => dispatch({type: "SET_PLAN_OPTION", value: {penUpAcceleration: Number(e.target.value)}})}
-        />
-      </label>
-      <label>
-        pen-up max velocity (mm/s)
-        <input
-          type="number"
-          value={state.planOptions.penUpMaxVelocity}
-          step="0.1"
-          min="0"
-          onChange={(e) => dispatch({type: "SET_PLAN_OPTION", value: {penUpMaxVelocity: Number(e.target.value)}})}
-        />
-      </label>
-      <label>
-        pen lift duration (s)
-        <input
-          type="number"
-          value={state.planOptions.penLiftDuration}
-          step="0.01"
-          min="0"
-          onChange={(e) => dispatch({type: "SET_PLAN_OPTION", value: {penLiftDuration: Number(e.target.value)}})}
-        />
-      </label>
-      <label>
-        pen drop duration (s)
-        <input
-          type="number"
-          value={state.planOptions.penDropDuration}
-          step="0.01"
-          min="0"
-          onChange={(e) => dispatch({type: "SET_PLAN_OPTION", value: {penDropDuration: Number(e.target.value)}})}
-        />
+      <div className="flex">
+        <label title="Acceleration when the pen is up (in mm/s^2)">
+          up acc. (mm/s<sup>2</sup>)
+          <input
+            type="number"
+            value={state.planOptions.penUpAcceleration}
+            step="0.1"
+            min="0"
+            onChange={(e) => dispatch({type: "SET_PLAN_OPTION", value: {penUpAcceleration: Number(e.target.value)}})}
+          />
+        </label>
+        <label title="Maximum velocity when the pen is up (in mm/s)">
+          up max vel. (mm/s)
+          <input
+            type="number"
+            value={state.planOptions.penUpMaxVelocity}
+            step="0.1"
+            min="0"
+            onChange={(e) => dispatch({type: "SET_PLAN_OPTION", value: {penUpMaxVelocity: Number(e.target.value)}})}
+          />
+        </label>
+      </div>
+      <div className="flex">
+        <label title="How long the pen takes to lift, in seconds">
+          pen lift duration (s)
+          <input
+            type="number"
+            value={state.planOptions.penLiftDuration}
+            step="0.01"
+            min="0"
+            onChange={(e) => dispatch({type: "SET_PLAN_OPTION", value: {penLiftDuration: Number(e.target.value)}})}
+          />
+        </label>
+        <label title="How long the pen takes to drop, in seconds">
+          pen drop duration (s)
+          <input
+            type="number"
+            value={state.planOptions.penDropDuration}
+            step="0.01"
+            min="0"
+            onChange={(e) => dispatch({type: "SET_PLAN_OPTION", value: {penDropDuration: Number(e.target.value)}})}
+          />
+        </div>
       </label>
     </div>
   </div>;

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -647,7 +647,7 @@ function PlanOptions({state}: {state: State}) {
     </div>
     <div>
       <div>
-        <label title="Re-order paths to minimize pen-up travel time">
+        <label className="flex-checkbox" title="Re-order paths to minimize pen-up travel time">
           <input
             type="checkbox"
             checked={state.planOptions.sortPaths}

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -616,9 +616,7 @@ function ResetToDefaultsButton() {
     dispatch({type: "SET_PLAN_OPTION", value: {...defaultPlanOptions}});
   };
 
-  return <div>
-    <button onClick={onClick}>reset all options</button>
-  </div>;
+  return <button className="button-link" onClick={onClick}>reset all options</button>;
 
 }
 

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -623,6 +623,14 @@ function ResetToDefaultsButton() {
 function PlanOptions({state}: {state: State}) {
   const dispatch = useContext(DispatchContext);
   return <div>
+    <label className="flex-checkbox" title="Re-order paths to minimize pen-up travel time">
+      <input
+        type="checkbox"
+        checked={state.planOptions.sortPaths}
+        onChange={(e) => dispatch({type: "SET_PLAN_OPTION", value: {sortPaths: Number(e.target.checked)}})}
+      />
+      sort paths
+    </label>
     <div className="horizontal-labels">
       <label title="point-joining radius (mm)" >
         <img src={pointJoinRadiusIcon} alt="point-joining radius (mm)"/>
@@ -646,16 +654,6 @@ function PlanOptions({state}: {state: State}) {
       </label>
     </div>
     <div>
-      <div>
-        <label className="flex-checkbox" title="Re-order paths to minimize pen-up travel time">
-          <input
-            type="checkbox"
-            checked={state.planOptions.sortPaths}
-            onChange={(e) => dispatch({type: "SET_PLAN_OPTION", value: {sortPaths: Number(e.target.checked)}})}
-          />
-          sort paths
-        </label>
-      </div>
       <label title="Remove paths that are shorter than this length (in mm)">
         minimum path length
         <input


### PR DESCRIPTION
Well hello. Your tricks worked on me @nornagon; I'm compelled to make a few style updates based on the recent interface additions 😄.

Let's take a look at the updates!

### 1. Drag Prompt Overlay
Now with 100% less dotted lines.

<img width="740" alt="Screen Shot 2019-03-30 at 10 36 51 AM" src="https://user-images.githubusercontent.com/2008156/55279653-1e85a780-52d8-11e9-9a3f-d0f3872cc3e9.png">

### 2. Smaller "reset all options" Control
`reset all options` is a little too destructive to warrant full button treatment, so it's now styled as a link.

![reset all](https://user-images.githubusercontent.com/2008156/55279697-850ac580-52d8-11e9-8e80-dc4188cdcee7.gif)

### 3. Group related labels
On my small laptop the More section has to be scrolled quite a bit, and the monotony of all of those inputs makes it hard to jump straight to the one you want. We can improve on this by breaking up the visual space — I chose to group related inputs on the same line to achieve this. The pen acceleration and velocity controls are now together, as are lift up/down.

The one downside here is that I needed to chop the labels down, but given the audience I think that'll be ok (I also added descriptive label titles for all of them).

<img width="260" alt="Screen Shot 2019-03-30 at 10 45 52 AM" src="https://user-images.githubusercontent.com/2008156/55279738-07938500-52d9-11e9-8fda-7cbe031043a9.png">

### 4. Move point/path join icons into the inputs
The point and path joining icons are great (I would love to add some more icons!) but break up the space in an odd way, so I've moved them inside of the inputs.

<img width="252" alt="Screen Shot 2019-03-30 at 10 47 20 AM" src="https://user-images.githubusercontent.com/2008156/55279747-3873ba00-52d9-11e9-9dc8-4b722077257e.png">

### 5. Sort paths checkbox
The `sort paths` checkbox has been moved to the top of the More section and given some styles.

![sort paths](https://user-images.githubusercontent.com/2008156/55279761-6f49d000-52d9-11e9-8c35-5ad4b042cbe5.gif)

### 6. Focus styles
I've increased the contrast on the input focus styles (as well as the More dropdown button) so that keyboard navigation is a little clearer. The buttons are also a little punchier and satisfying to click 🤠.

![buttons](https://user-images.githubusercontent.com/2008156/55279785-bc2da680-52d9-11e9-8267-ea0c7f927872.gif)

@nornagon if you like these updates, please merge and release at your leisure ✌️