### PR TITLE
Bump `flatten-svg` dependency to 0.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   "dependencies": {
     "cors": "^2.8.5",
     "express": "^4.16.4",
-    "flatten-svg": "^0.1.1",
+    "flatten-svg": "^0.1.2",
     "serialport": "^7.1.3",
     "wake-lock": "^0.2.0",
     "ws": "^6.1.3",


### PR DESCRIPTION
To pull in the fix for https://github.com/nornagon/saxi/issues/34