### PR TITLE
Added loading overlay on replanning and file loading

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -61,10 +61,27 @@ path {
   background-color: white;
   position: relative;
 }
+
+.preview-loader {
+  align-items: center;
+  background: rgba(0, 0, 0, 0.2);
+  color: whitesmoke;
+  display: flex;
+  font-size: 36px;
+  font-weight: bold;
+  height: 100%;
+  justify-content: center;
+  left: 0;
+  position: absolute;
+  top: 0;
+  width: 100%;
+}
+
 .preview > svg {
   display: block;
   contain: strict;
 }
+
 .preview > svg:not(:first-child) {
   position: absolute;
   transform: translateZ(0.001px);

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -808,6 +808,7 @@ function Root({driver}: {driver: Driver}) {
       const file = item.getAsFile();
       const reader = new FileReader();
       setIsLoadingFile(true);
+      setPlan(null);
       reader.onload = () => {
         dispatch(setPaths(readSvg(reader.result as string)));
         document.body.classList.remove("dragover");
@@ -845,6 +846,8 @@ function Root({driver}: {driver: Driver}) {
 
   const previewArea = useRef(null);
   const previewSize = useComponentSize(previewArea);
+  const showDragTarget = !plan && !isLoadingFile && !isPlanning;
+
   return <DispatchContext.Provider value={dispatch}>
     <div className={`root ${state.connected ? "connected" : "disconnected"}`}>
       <div className="control-panel">
@@ -885,7 +888,7 @@ function Root({driver}: {driver: Driver}) {
           plan={plan}
         />
         <PlanLoader isPlanning={isPlanning} isLoadingFile={isLoadingFile} />
-        {plan ? null : <DragTarget/>}
+        {showDragTarget ? <DragTarget/> : null}
       </div>
     </div>
   </DispatchContext.Provider>;


### PR DESCRIPTION
Fixes #27

I added a simple overlay when file is being loaded and on replanning as well. It uses styles similar to the "Drop SVG here" element.

Here is video of the loader in action: https://imgur.com/a/HAPuTTg

