### PR TITLE
feat: simulate pen stroke width

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -208,6 +208,8 @@ export function cli(argv: string[]): void {
           penUpHeight: args["pen-up-height"],
           penDownHeight: args["pen-down-height"],
 
+          penStrokeWidth: 0.5, // unused in this case, since this is only used by the preview
+
           penDownAcceleration: args["pen-down-acceleration"],
           penDownMaxVelocity: args["pen-down-max-velocity"],
           penDownCorneringFactor: args["pen-down-cornering-factor"],

--- a/src/planning.ts
+++ b/src/planning.ts
@@ -14,6 +14,7 @@ export interface PlanOptions {
 
   penUpHeight: number;
   penDownHeight: number;
+  penStrokeWidth: number;
   pointJoinRadius: number;
   pathJoinRadius: number;
 
@@ -37,6 +38,7 @@ export interface PlanOptions {
 export const defaultPlanOptions: PlanOptions = {
   penUpHeight: 50,
   penDownHeight: 60,
+  penStrokeWidth: 0.5,
   pointJoinRadius: 0,
   pathJoinRadius: 0.5,
   paperSize: PaperSize.standard.ArchA.landscape,

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -308,6 +308,22 @@ function PenHeight({state, driver}: {state: State; driver: Driver}) {
   </Fragment>;
 }
 
+function PenWidth({state}: {state: State}) {
+  const dispatch = useContext(DispatchContext);
+  
+  return <label>
+    stroke width (mm)
+    <input
+      type="number"
+      value={state.planOptions.penStrokeWidth}
+      min="0"
+      max="10"
+      step="0.1"
+      onChange={(e) => dispatch({type: "SET_PLAN_OPTION", value: {penStrokeWidth: Number(e.target.value)}})}
+    />
+  </label>;
+}
+
 function SwapPaperSizesButton({ onClick }: { onClick: () => void }) {
   return <svg
     className="paper-sizes__swap"
@@ -423,7 +439,7 @@ function PlanPreview(
           <path
             key={i}
             d={line.reduce((m, {x, y}, j) => m + `${j === 0 ? "M" : "L"}${x} ${y}`, "")}
-            style={i % 2 === 0 ? {stroke: "rgba(0, 0, 0, 0.3)", strokeWidth: 0.5} : {}}
+            style={i % 2 === 0 ? {stroke: "rgba(0, 0, 0, 0.3)", strokeWidth: 0.5} : { stroke: "rgba(0, 0, 0, 0.8)", strokeWidth: state.planOptions.penStrokeWidth * 10 }}
           />
         )}
       </g>;
@@ -859,6 +875,7 @@ function Root({driver}: {driver: Driver}) {
         <div className="section-body">
           <PenHeight state={state} driver={driver} />
           <MotorControl driver={driver} />
+          <PenWidth state={state} />
           <ResetToDefaultsButton />
         </div>
         <div className="section-header">paper</div>

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -439,7 +439,7 @@ function PlanPreview(
           <path
             key={i}
             d={line.reduce((m, {x, y}, j) => m + `${j === 0 ? "M" : "L"}${x} ${y}`, "")}
-            style={i % 2 === 0 ? {stroke: "rgba(0, 0, 0, 0.3)", strokeWidth: 0.5} : { stroke: "rgba(0, 0, 0, 0.8)", strokeWidth: state.planOptions.penStrokeWidth * 10 }}
+            style={i % 2 === 0 ? {stroke: "rgba(0, 0, 0, 0.3)", strokeWidth: 0.5} : { stroke: "rgba(0, 0, 0, 0.8)", strokeWidth: state.planOptions.penStrokeWidth * Device.Axidraw.stepsPerMm }}
           />
         )}
       </g>;

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -311,7 +311,7 @@ function PenHeight({state, driver}: {state: State; driver: Driver}) {
 function PenWidth({state}: {state: State}) {
   const dispatch = useContext(DispatchContext);
   
-  return <label>
+  return <label title="Width of lines in preview. Does not affect plot.">
     stroke width (mm)
     <input
       type="number"


### PR DESCRIPTION
Implements idea from #74

Also makes stroke colour transparent to show potentially overlapping strokes. 