### PR TITLE
Added simple plot progress at the top

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -114,6 +114,21 @@ path {
   font-size: 36px;
 }
 
+.progress {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  text-align: center;
+  font-size: 12px;
+}
+
+.progress-bar {
+  background-color: var(--purple-light);
+  height: 3px;
+  margin-bottom: 2px;
+}
+
 .control-panel {
   position: relative;
   flex: 0 0 var(--panel-width);


### PR DESCRIPTION
As coloring line as plot goes is expensive, I just added a small progress at the top which counts how many lines have been drawn. Combining it with "color based on order" option, I think it works pretty well, and gives user a sense how the plot is going.

I increased preview padding slightly to accommodate for the progress bar.

<img width="600" alt="1" src="https://user-images.githubusercontent.com/776788/142586461-90c6a5f6-00ac-4ef7-9b90-7b4133b58fd7.png">

And the whole window:

<img width="1792" alt="Screen Shot 2021-11-19 at 8 53 53 AM" src="https://user-images.githubusercontent.com/776788/142586323-62da9916-96a9-4934-a8c6-c6fc7664e774.png">

