### PR TITLE
Added time remaining on the UI

### DIFF
--- a/src/planning.ts
+++ b/src/planning.ts
@@ -277,8 +277,8 @@ export class Plan {
   public constructor(motions: Motion[]) {
     this.motions = motions;
   }
-  public duration(): number {
-    return this.motions.map((m) => m.duration()).reduce((a, b) => a + b, 0);
+  public duration(start: number = 0): number {
+    return this.motions.slice(start).map((m) => m.duration()).reduce((a, b) => a + b, 0);
   }
   public motion(i: number) { return this.motions[i]; }
 

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -589,6 +589,39 @@ function PlanStatistics({plan}: {plan: Plan}) {
   </div>;
 }
 
+function TimeLeft({plan, progress, currentLineStartedTime, paused}: {
+  plan: Plan;
+  progress: number | null; 
+  currentLineStartedTime: Date | null;
+  paused: boolean;
+}) {
+  const [_, setTime] = useState(new Date());
+
+  // Interval that ticks every second to rerender
+  // and recalculate time remaining for long lines
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setTime(new Date());
+    }, 1000);
+
+    () => {
+      clearInterval(interval);
+    }
+  }, [setTime])
+
+  if (!plan || !plan.duration || progress === null || paused) {
+    return null;
+  }
+
+  const currentLineProgress = (new Date().getTime() - currentLineStartedTime.getTime()) / 1000;
+  const duration = plan.duration(progress);
+
+  return <div className="duration">
+    <div className="time-remaining-label">Time remaining:</div>
+    <div><strong>{formatDuration(duration - currentLineProgress)}</strong></div>
+  </div>;
+}
+
 function PlanPreview(
   {state, previewSize, plan}: {
     state: State;
@@ -1084,6 +1117,11 @@ function Root() {
     };
   });
 
+  // Each time new line is started, save the start time
+  const currentLineStartedTime = useMemo(() => {
+    return new Date();
+  }, [state.progress, plan, state.paused]);
+
   const previewArea = useRef(null);
   const previewSize = useComponentSize(previewArea);
   const showDragTarget = !plan && !isLoadingFile && !isPlanning;
@@ -1119,6 +1157,12 @@ function Root() {
           <div className="section-header">plot</div>
           <div className="section-body section-body__plot">
             <PlanStatistics plan={plan} />
+            <TimeLeft 
+              plan={plan} 
+              progress={state.progress} 
+              currentLineStartedTime={currentLineStartedTime}
+              paused={state.paused}
+            />
             <PlotButtons plan={plan} isPlanning={isPlanning} state={state} driver={driver} />
           </div>
         </div>

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -589,22 +589,22 @@ function PlanStatistics({plan}: {plan: Plan}) {
   </div>;
 }
 
-function TimeLeft({plan, progress, currentLineStartedTime, paused}: {
+function TimeLeft({plan, progress, currentMotionStartedTime, paused}: {
   plan: Plan;
   progress: number | null; 
-  currentLineStartedTime: Date | null;
+  currentMotionStartedTime: Date | null;
   paused: boolean;
 }) {
   const [_, setTime] = useState(new Date());
 
   // Interval that ticks every second to rerender
-  // and recalculate time remaining for long lines
+  // and recalculate time remaining for long motions
   useEffect(() => {
     const interval = setInterval(() => {
       setTime(new Date());
     }, 1000);
 
-    () => {
+    return () => {
       clearInterval(interval);
     }
   }, [setTime])
@@ -613,12 +613,12 @@ function TimeLeft({plan, progress, currentLineStartedTime, paused}: {
     return null;
   }
 
-  const currentLineProgress = (new Date().getTime() - currentLineStartedTime.getTime()) / 1000;
+  const currentMotionTimeSpent = (new Date().getTime() - currentMotionStartedTime.getTime()) / 1000;
   const duration = plan.duration(progress);
 
   return <div className="duration">
-    <div className="time-remaining-label">Time remaining:</div>
-    <div><strong>{formatDuration(duration - currentLineProgress)}</strong></div>
+    <div className="time-remaining-label">Time remaining</div>
+    <div><strong>{formatDuration(duration - currentMotionTimeSpent)}</strong></div>
   </div>;
 }
 
@@ -1117,8 +1117,8 @@ function Root() {
     };
   });
 
-  // Each time new line is started, save the start time
-  const currentLineStartedTime = useMemo(() => {
+  // Each time new motion is started, save the start time
+  const currentMotionStartedTime = useMemo(() => {
     return new Date();
   }, [state.progress, plan, state.paused]);
 
@@ -1160,7 +1160,7 @@ function Root() {
             <TimeLeft 
               plan={plan} 
               progress={state.progress} 
-              currentLineStartedTime={currentLineStartedTime}
+              currentMotionStartedTime={currentMotionStartedTime}
               paused={state.paused}
             />
             <PlotButtons plan={plan} isPlanning={isPlanning} state={state} driver={driver} />


### PR DESCRIPTION
Closes #12 

Continuing my work from https://github.com/nornagon/saxi/pull/97, trying to display plot progress. I used the approach you described in https://github.com/nornagon/saxi/issues/12. But I displayed time left, rather than competition time.

For long lines, component ticks every second and updates the time by delta time.

<img width="1203" alt="Screen Shot 2021-11-22 at 2 01 59 PM" src="https://user-images.githubusercontent.com/776788/142866392-06ea90e7-6852-4742-b345-093c05db4417.png">

