### PR TITLE
Use wss protocol when page is accessed over https

### DIFF
--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -236,7 +236,10 @@ class SaxiDriver implements Driver {
   }
 
   public connect() {
-    this.socket = new WebSocket(`ws://${document.location.host}/chat`);
+
+    const websocketProtocol = document.location.protocol === "https:" ? "wss" : "ws";
+    this.socket = new WebSocket(`${websocketProtocol}://${document.location.host}/chat`);
+    
     this.socket.addEventListener("open", () => {
       console.log(`Connected to EBB server.`);
       this.connected = true;


### PR DESCRIPTION
If saxi is accessed over HTTPS instead of HTTP (in my case using traefik as a reverse proxy),  then the front end will fail to load in chrome due to:

```
Mixed Content: The page at 'https://saxi.local.taco.network/' was loaded over HTTPS, but attempted to connect to the insecure WebSocket endpoint 'ws://saxi.local.taco.network/chat'. This request has been blocked; this endpoint must be available over WSS.

DOMException: Failed to construct 'WebSocket': An insecure WebSocket connection may not be initiated from a page loaded over HTTPS.
```

This change detects ifs the page is being accessed over `HTTPS` and if so, change the WebSocket protocol to be `wss` instead of `ws`