### PR TITLE
bump version to use optimize-paths 1.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "saxi",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.14.0",
+      "name": "saxi",
+      "version": "0.14.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "cors": "^2.8.5",
         "express": "^4.16.4",
         "flatten-svg": "^0.2.1",
-        "optimize-paths": "^1.2.0",
+        "optimize-paths": "^1.2.2",
         "serialport": "^9.2.0",
         "svgdom": "0.0.21",
         "wake-lock": "^0.2.0",
@@ -9412,9 +9413,9 @@
       }
     },
     "node_modules/optimize-paths": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/optimize-paths/-/optimize-paths-1.2.1.tgz",
-      "integrity": "sha512-ZE2RVeIs+MQK1th1HpSXBoeYumAfWaTmwX5FFRjo6VLUtPvxFzr5zWBpRy4NXwQXBHAl5Pfrv3rMmYq/C5O3aA==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/optimize-paths/-/optimize-paths-1.2.2.tgz",
+      "integrity": "sha512-JSlj+EL4QMnPb3K6StyZo3rT7JbQZysFfnsJi3cfn9qSG6cg6+Zi6GhGrPxiaCHHPS2SmLqzCctFjTr1VFKTPQ==",
       "dependencies": {
         "rbush": "^3.0.1",
         "tinyqueue": "^2.0.3"
@@ -21311,9 +21312,9 @@
       }
     },
     "optimize-paths": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/optimize-paths/-/optimize-paths-1.2.1.tgz",
-      "integrity": "sha512-ZE2RVeIs+MQK1th1HpSXBoeYumAfWaTmwX5FFRjo6VLUtPvxFzr5zWBpRy4NXwQXBHAl5Pfrv3rMmYq/C5O3aA==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/optimize-paths/-/optimize-paths-1.2.2.tgz",
+      "integrity": "sha512-JSlj+EL4QMnPb3K6StyZo3rT7JbQZysFfnsJi3cfn9qSG6cg6+Zi6GhGrPxiaCHHPS2SmLqzCctFjTr1VFKTPQ==",
       "requires": {
         "rbush": "^3.0.1",
         "tinyqueue": "^2.0.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saxi",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Drive the AxiDraw pen plotter",
   "homepage": "https://github.com/nornagon/saxi",
   "repository": "github:nornagon/saxi",
@@ -70,7 +70,7 @@
     "cors": "^2.8.5",
     "express": "^4.16.4",
     "flatten-svg": "^0.2.1",
-    "optimize-paths": "^1.2.0",
+    "optimize-paths": "^1.2.2",
     "serialport": "^9.2.0",
     "svgdom": "0.0.21",
     "wake-lock": "^0.2.0",


### PR DESCRIPTION
Major improvement on plot time 🤖✏️💨

Before:
![](https://user-images.githubusercontent.com/1162231/168015900-9bf14f83-2e23-409c-90c7-00bdcb174b08.png)

After:
![](https://user-images.githubusercontent.com/1162231/168016145-0c0c3bda-e88c-4383-bac4-d3710a97a522.png)

