### PR TITLE
Pause after X seconds feature

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -184,6 +184,11 @@ export function cli(argv: string[]): void {
           type: "number",
           default: defaultPlanOptions.rotateDrawing
         })
+        .option("pause-after", {
+          describe: "Pause plot after X seconds",
+          type: "number",
+          default: defaultPlanOptions.pauseAfter
+        })
         .check((args) => {
           if (args.landscape && args.portrait) {
             throw new Error("Only one of --portrait and --landscape may be specified")
@@ -230,6 +235,7 @@ export function cli(argv: string[]): void {
           minimumPathLength: args["minimum-path-length"],
           pathJoinRadius: args["path-join-radius"],
           pointJoinRadius: args["point-join-radius"],
+          pauseAfter: args["pause-after"],
         }
         const p = replan(linesToVecs(lines), planOptions)
         console.log(`${p.motions.length} motions, estimated duration: ${formatDuration(p.duration())}`)

--- a/src/planning.ts
+++ b/src/planning.ts
@@ -33,6 +33,7 @@ export interface PlanOptions {
   cropToMargins: boolean;
 
   minimumPathLength: number;
+  pauseAfter: number;
 }
 
 export const defaultPlanOptions: PlanOptions = {
@@ -62,6 +63,7 @@ export const defaultPlanOptions: PlanOptions = {
   cropToMargins: true,
 
   minimumPathLength: 0,
+  pauseAfter: 0,
 };
 
 interface Instant {

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -804,9 +804,21 @@ function PlotButtons(
     driver.pause();
   }
   function resume() {
+    if (state.planOptions.pauseAfter && state.planOptions.pauseAfter>0) {
+      setTimeout(() => {
+        console.log('Plot paused again after ', state.planOptions.pauseAfter, ' seconds');
+        driver.pause();
+      }, state.planOptions.pauseAfter * 1000);
+    }
     driver.resume();
   }
   function plot(plan: Plan) {
+    if (state.planOptions.pauseAfter && state.planOptions.pauseAfter>0) {
+      setTimeout(() => {
+        console.log('Plot paused after ', state.planOptions.pauseAfter, ' seconds');
+        driver.pause();
+      }, state.planOptions.pauseAfter * 1000);
+    }
     driver.plot(plan);
   }
 
@@ -953,6 +965,16 @@ function PlanOptions({state}: {state: State}) {
           step="0.01"
           min="0"
           onChange={(e) => dispatch({type: "SET_PLAN_OPTION", value: {penDownCorneringFactor: Number(e.target.value)}})}
+        />
+      </label>
+      <label>
+        Pause plot after X seconds
+        <input
+          type="number"
+          value={state.planOptions.pauseAfter}
+          step="60"
+          min="0"
+          onChange={(e) => dispatch({type: "SET_PLAN_OPTION", value: {pauseAfter: Number(e.target.value)}})}
         />
       </label>
       <div className="flex">


### PR DESCRIPTION
Sometime, we need to do action on the pen at regular interval (like shaking a posca pen).
This patch define a UI field to ask for a pause after X seconds. Then the plot will stop after X seconds.
After a resume, the plot will honor any change to the UI field, and stop again after X seconds, and so on.

This should allow to do any regular operation on a pen, without the need to stay near the plot to press pause at the right time.