### PR TITLE
chore(deps): upgrade typescript to v5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
         "style-loader": "^0.23.1",
         "ts-jest": "^29.0.0",
         "ts-loader": "^5.3.3",
-        "typescript": "~4.6",
+        "typescript": "~5.0",
         "webpack": "^5.0.0",
         "webpack-cli": "^5.0.0",
         "worker-loader": "^2.0.0"
@@ -10888,16 +10888,16 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "node_modules/typescript": {
-      "version": "4.6.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
-      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
+      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=12.20"
       }
     },
     "node_modules/unicode-properties": {
@@ -19915,9 +19915,9 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typescript": {
-      "version": "4.6.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
-      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
+      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
       "dev": true
     },
     "unicode-properties": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "style-loader": "^0.23.1",
     "ts-jest": "^29.0.0",
     "ts-loader": "^5.3.3",
-    "typescript": "~4.6",
+    "typescript": "~5.0",
     "webpack": "^5.0.0",
     "webpack-cli": "^5.0.0",
     "worker-loader": "^2.0.0"


### PR DESCRIPTION
Note: Although TypeScript 5.1 runs fine, `typescript-eslint` emits a warning since it [currently](https://typescript-eslint.io/users/dependency-versions#typescript) only supports `<5.1.0`

Works on real hardware.