### PR TITLE
Speed up CI by avoiding double compile

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -27,5 +27,4 @@ jobs:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
     - run: npm ci
-    - run: npm run build --if-present
     - run: npm test


### PR DESCRIPTION
@nornagon  I recommend looking at this PR first. :)

Since `npm ci` already compiles the project, `npm build` is redundant.  Dropping it saves ~30s, a 33% speedup.  

Before:
![Screenshot 2023-07-12 at 3 40 58 PM](https://github.com/nornagon/saxi/assets/52292902/0659433d-b8a1-497b-81b5-91da09c75e97)

After:
![Screenshot 2023-07-12 at 3 41 15 PM](https://github.com/nornagon/saxi/assets/52292902/767792c4-05fd-4325-ae88-29978b4bfed4)
