### PR TITLE
chore(deps): update dependency @types/node to 14.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,9 @@
         "webpack": "^5.0.0",
         "webpack-cli": "^5.0.0",
         "worker-loader": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@types/cors": "^2.8.4",
         "@types/express": "^4.16.1",
         "@types/jest": "^29.0.0",
-        "@types/node": "^10.17.28",
+        "@types/node": "^14.0.0",
         "@types/react": "^18.0.0",
         "@types/react-dom": "^18.0.0",
         "@types/serialport": "^8.0.0",
@@ -1760,9 +1760,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "10.17.28",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.28.tgz",
-      "integrity": "sha512-dzjES1Egb4c1a89C7lKwQh8pwjYmlOAG9dW1pBgxEk57tMrLnssOfEthz8kdkNaBd7lIqQx7APm5+mZ619IiCQ==",
+      "version": "14.18.53",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.53.tgz",
+      "integrity": "sha512-soGmOpVBUq+gaBMwom1M+krC/NNbWlosh4AtGA03SyWNDiqSKtwp7OulO1M6+mg8YkHMvJ/y0AkCeO8d1hNb7A==",
       "dev": true
     },
     "node_modules/@types/prettier": {
@@ -7012,32 +7012,6 @@
         "node": ">=6.11.5"
       }
     },
-    "node_modules/loader-utils": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
-      "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
-      "dev": true,
-      "dependencies": {
-        "big.js": "^5.2.2",
-        "emojis-list": "^3.0.0",
-        "json5": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/loader-utils/node_modules/json5": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
-      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
-      "dev": true,
-      "dependencies": {
-        "minimist": "^1.2.0"
-      },
-      "bin": {
-        "json5": "lib/cli.js"
-      }
-    },
     "node_modules/locate-path": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -11782,9 +11756,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "10.17.28",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.28.tgz",
-      "integrity": "sha512-dzjES1Egb4c1a89C7lKwQh8pwjYmlOAG9dW1pBgxEk57tMrLnssOfEthz8kdkNaBd7lIqQx7APm5+mZ619IiCQ==",
+      "version": "14.18.53",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.53.tgz",
+      "integrity": "sha512-soGmOpVBUq+gaBMwom1M+krC/NNbWlosh4AtGA03SyWNDiqSKtwp7OulO1M6+mg8YkHMvJ/y0AkCeO8d1hNb7A==",
       "dev": true
     },
     "@types/prettier": {
@@ -15741,28 +15715,6 @@
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
       "integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
       "dev": true
-    },
-    "loader-utils": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
-      "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
-      "dev": true,
-      "requires": {
-        "big.js": "^5.2.2",
-        "emojis-list": "^3.0.0",
-        "json5": "^1.0.1"
-      },
-      "dependencies": {
-        "json5": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
-          "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
-          "dev": true,
-          "requires": {
-            "minimist": "^1.2.0"
-          }
-        }
-      }
     },
     "locate-path": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@types/cors": "^2.8.4",
     "@types/express": "^4.16.1",
     "@types/jest": "^29.0.0",
-    "@types/node": "^10.17.28",
+    "@types/node": "^14.0.0",
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",
     "@types/serialport": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,9 @@
     "ws": "^8.0.0",
     "yargs": "^15.4.1"
   },
+  "engines": {
+    "node": ">=14.0.0"
+  },
   "jest": {
     "preset": "ts-jest"
   },


### PR DESCRIPTION
The `@types/node` package got out of sync with the tested versions of node.

Versions higher than `14` trigger type errors in `express-server-static-core`.  (They have no practical runtime effect, but break `tsc`)

```
Error: node_modules/@types/express-serve-static-core/index.d.ts(471,18): 
error TS2430: Interface 'Response' incorrectly extends interface 
'ServerResponse<IncomingMessage>'.
  Property 'req' is optional in type 'Response' but required in type 
'ServerResponse<IncomingMessage>'.
Error: src/server.ts(18,11): error TS2769: No overload matches this call.
  The last overload gave the following error.
    Argument of type 'NextHandleFunction' is not assignable to parameter 
of type 'PathParams'.
```

I know you typically don't like `package-lock.json` updates but this one is so short I left it in.