### PR TITLE
Add basic server smoke test

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",
     "@types/serialport": "^8.0.0",
+    "@types/supertest": "^2.0.12",
     "@types/w3c-web-serial": "^1.0.2",
     "@types/ws": "8.0.0 - 8.5.4",
     "@types/yargs": "^12.0.8",
@@ -68,7 +69,6 @@
     "worker-loader": "^3.0.0"
   },
   "dependencies": {
-    "@types/supertest": "^2.0.12",
     "cors": "^2.8.5",
     "express": "^4.16.4",
     "flatten-svg": "^0.2.1",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "rimraf": "^5.0.0",
     "semver": "^7.5.2",
     "style-loader": "^3.0.0",
+    "supertest": "^6.3.3",
     "ts-jest": "^29.0.0",
     "ts-loader": "^9.0.0",
     "typescript": "~5.0",
@@ -67,6 +68,7 @@
     "worker-loader": "^3.0.0"
   },
   "dependencies": {
+    "@types/supertest": "^2.0.12",
     "cors": "^2.8.5",
     "express": "^4.16.4",
     "flatten-svg": "^0.2.1",

--- a/src/__tests__/server-smoke.test.ts
+++ b/src/__tests__/server-smoke.test.ts
@@ -14,7 +14,7 @@ describe('Server Smoke Test', () => {
 let server: Server;
 
   beforeAll(async () => {
-    server = await startServer(9080);
+    server = await startServer(0);
   });
 
   afterAll( () => {

--- a/src/__tests__/server-smoke.test.ts
+++ b/src/__tests__/server-smoke.test.ts
@@ -1,0 +1,29 @@
+import { startServer } from '../server';
+import type { Server } from 'http';
+import request from 'supertest';
+
+jest.mock("../server", () => {
+  const original = jest.requireActual("../server");
+  return {
+      ...original,
+      ebbs: jest.fn()
+  };
+});
+
+describe('Server Smoke Test', () => {
+let server: Server;
+
+  beforeAll(async () => {
+    server = await startServer(9080);
+  });
+
+  afterAll( () => {
+    server.close();
+  });
+
+  test('POST /cancel should return 200 OK', async () => {
+    const response = await request(server).post('/cancel');
+    expect(response.status).toBe(200);
+  });
+
+});

--- a/src/__tests__/server-smoke.test.ts
+++ b/src/__tests__/server-smoke.test.ts
@@ -1,12 +1,14 @@
-import { startServer } from '../server';
+import { startServer, waitForEbb } from '../server';
 import type { Server } from 'http';
 import request from 'supertest';
 
+jest.mock("../serialport-serialport")
+jest.mock("../ebb")
 jest.mock("../server", () => {
   const original = jest.requireActual("../server");
   return {
       ...original,
-      ebbs: jest.fn()
+      waitForEbb: jest.fn(()=> 'fake-ebb-path'),
   };
 });
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -10,6 +10,7 @@ import { SerialPortSerialPort } from "./serialport-serialport";
 import { EBB } from "./ebb";
 import { Device, PenMotion, Motion, Plan } from "./planning";
 import { formatDuration } from "./util";
+import * as self from './server'  // for mocking
 
 export function startServer(port: number, device: string | null = null, enableCors = false, maxPayloadSize = "200mb"): Promise<http.Server> {
   const app = express();
@@ -254,8 +255,8 @@ async function listEBBs() {
   return ports.filter(isEBB).map((p) => p.path);
 }
 
-async function waitForEbb() {
-// eslint-disable-next-line no-constant-condition
+export async function waitForEbb() {
+  // eslint-disable-next-line no-constant-condition
   while (true) {
     const ebbs = await listEBBs();
     if (ebbs.length) {
@@ -268,7 +269,7 @@ async function waitForEbb() {
 async function* ebbs(path?: string) {
   while (true) {
     try {
-      const com = path || (await waitForEbb());
+      const com = path || (await self.waitForEbb());  // use self-import for mocking
       console.log(`Found EBB at ${com}`);
       const port = await tryOpen(com);
       const closed = new Promise((resolve) => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -11,7 +11,7 @@ import { EBB } from "./ebb";
 import { Device, PenMotion, Motion, Plan } from "./planning";
 import { formatDuration } from "./util";
 
-export function startServer(port: number, device: string | null = null, enableCors = false, maxPayloadSize = "200mb") {
+export function startServer(port: number, device: string | null = null, enableCors = false, maxPayloadSize = "200mb"): Promise<http.Server> {
   const app = express();
 
   app.use("/", express.static(path.join(__dirname, "..", "ui")));
@@ -218,7 +218,7 @@ export function startServer(port: number, device: string | null = null, enableCo
     await plotter.postPlot();
   }
 
-  return new Promise((resolve) => {
+  return new Promise<http.Server>((resolve) => {
     server.listen(port, () => {
       async function connect() {
         for await (const d of ebbs(device)) {


### PR DESCRIPTION
Requires #170 since transient `superagent` silently dropped Node 12.  (https://github.com/DefinitelyTyped/DefinitelyTyped/issues/58445)

This is a basic smoke test to make sure the Express server starts (sometimes dependency updates break it).  It currently works, but has a warning:

> A worker process has failed to exit gracefully and has been force exited. 
This is likely caused by tests leaking due to improper teardown. Try running with --detectOpenHandles to find leaks. Active timers can also cause this, ensure that .unref() was called on them.

I'm nearly certain this is caused by `server.ts` trying to connect to the EBB, but haven't quite figured out how to mock it out.  Help would be appreciated.
