### PR TITLE
Disable layer select while plotting

### DIFF
--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -781,6 +781,7 @@ function LayerSelector({state}: {state: State}) {
         value={[...selectedLayers]}
         onChange={layersChanged}
         size={3}
+        disabled={state.progress != null}
       >
         {layers.map((layer) => <option key={layer}>{layer}</option>)}
       </select>


### PR DESCRIPTION
See https://github.com/alexrudd2/saxi/issues/102

If you click on the layer select while plotting, the UI partially crashes.  Although it would be cool to turn on/off layers and create a new plan on the fly, right now it's just broken.