### PR TITLE
Fix multiple connects causing erratic plots

### DIFF
--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -240,7 +240,7 @@ class SaxiDriver implements Driver {
 
     const websocketProtocol = document.location.protocol === "https:" ? "wss" : "ws";
     this.socket = new WebSocket(`${websocketProtocol}://${document.location.host}/chat`);
-    
+
     this.socket.addEventListener("open", () => {
       console.log(`Connected to EBB server.`);
       this.connected = true;
@@ -1043,9 +1043,18 @@ function PortSelector({driver, setDriver}: {driver: Driver; setDriver: (d: Drive
 }
 
 function Root() {
-  const [driver, setDriver] = useState(
-    IS_WEB ? null as Driver | null : SaxiDriver.connect()
-  )
+  const [driver, setDriver] = useState<Driver | null>(null);
+  const [isDriverConnected, setIsDriverConnected] = useState(false);
+  useEffect(() => {
+    if (isDriverConnected) return
+    if (IS_WEB) {
+      setDriver(null as Driver);
+    } else {
+      setDriver(SaxiDriver.connect());
+    }
+    setIsDriverConnected(true);
+  }, [isDriverConnected]);
+
   const [state, dispatch] = useReducer(reducer, initialState);
   const [isPlanning, plan, setPlan] = usePlan(state.paths, state.planOptions);
   const [isLoadingFile, setIsLoadingFile] = useState(false);
@@ -1117,7 +1126,7 @@ function Root() {
       document.body.removeEventListener("dragleave", ondragleave);
       document.removeEventListener("paste", onpaste);
     };
-  });
+  }, []);
 
   // Each time new motion is started, save the start time
   const currentMotionStartedTime = useMemo(() => {


### PR DESCRIPTION
See https://github.com/alexrudd2/saxi/pull/113.  Closes https://github.com/nornagon/saxi/issues/194.  Closes https://github.com/nornagon/saxi/issues/131

### summary
`saxi` is usually OK on a fast laptop, but can cause erratic and jerky plots on smaller devices like a Raspberry Pi.   This PR smooths things out.


### details
`0.0.15` code creates up to 5 duplicate WebSocket connections, as an unintended side effort of adding WebSerial.  They occur even when WebSerial isn't being used.
![image](https://github.com/nornagon/saxi/assets/52292902/cd16b688-9f5a-4dd0-97df-6370cf57d9f1)

This PR removes the duplicates with two ways:
- The event listeners for drag-n-drop don't need to be called multiple times, so pass `[]` as the second argument to `useEffect`.
- Wrap the `SaxiDriver.connect()` call in a flag so it doesn't get called multiple times in `Root()`.

