### PR TITLE
ebb: Poll the button to pause/resume the plot

### DIFF
--- a/src/ebb.ts
+++ b/src/ebb.ts
@@ -51,6 +51,8 @@ export class EBB {
           }
         }
       }))
+    this.firmwareVersion().then((version) => console.log("Firmware version", version));
+    this.queryGeneral(); // clear the button press status on startup
   }
 
   private get stepMultiplier() {
@@ -106,6 +108,11 @@ export class EBB {
     } catch (err) {
       throw new Error(`Error in response to queryM '${cmd}': ${err.message}`);
     }
+  }
+
+  /** Send the new General Query command to get limit switch, button and fifo status */
+  public async queryGeneral(): Promise<number> {
+    return parseInt(await this.query("QG"), 16);
   }
 
   /** Send a raw command to the EBB and expect a single "OK" line in return. */
@@ -230,6 +237,24 @@ export class EBB {
     }
   }
 
+  public async sleep(ms: number) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  public async checkButtonAndWait() {
+    if (!await this.queryButton())
+      return;
+    console.log("BUTTON PAUSED");
+    // wait for the button to have been released, then pressed again
+    // is there a better way to do this?
+    while (await this.queryButton()) await this.sleep(100);
+    console.log("BUTTON released");
+    while (!await this.queryButton()) await this.sleep(100);
+    console.log("BUTTON RESTART");
+    while (await this.queryButton()) await this.sleep(100);
+    console.log("BUTTON released");
+  }
+
   public async executeBlockWithLM(block: Block): Promise<void> {
     const [errX, stepsX] = modf((block.p2.x - block.p1.x) * this.stepMultiplier + this.error.x);
     const [errY, stepsY] = modf((block.p2.y - block.p1.y) * this.stepMultiplier + this.error.y);
@@ -251,6 +276,7 @@ export class EBB {
    */
   public async executeXYMotionWithLM(plan: XYMotion): Promise<void> {
     for (const block of plan.blocks) {
+      await this.checkButtonAndWait();
       await this.executeBlockWithLM(block);
     }
   }
@@ -381,7 +407,8 @@ export class EBB {
   }
 
   public async queryButton(): Promise<boolean> {
-    return (await this.queryM("QB"))[0] === "1";
+    const resp = await this.queryGeneral();
+    return (resp & (1<<5)) != 0;
   }
 
   /**


### PR DESCRIPTION
After sending every point to the plotter, query the status of the physical button and pause if the operator has pressed it.  If so, busy poll for it to be released and pressed again to resume the plot.

Also report the EBB firmware version on startup.